### PR TITLE
fix readme env typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A suitable [conda](https://conda.io/) environment named `DifFace` can be created
 
 ```
 conda env create -f environment.yaml
-conda activate taming
+conda activate DifFace
 ```
 
 ## Inference


### PR DESCRIPTION
Hi Zongsheng,

Thanks for your amazing work. I just found a minor typo in README.md, which is wrong as the name used in the environment.yaml is `DifFace` while `taming` is used in README.md. I supposed you forgot to change the name when modifying from the VQ-GAN repo LOL. Please see as follows:

### Env name in README.md
https://github.com/zsyOAOA/DifFace/blob/65e8fef351b40177eaa6cb281aa997a644c0ed77/README.md?plain=1#L33
### Env name in the environment.yaml
https://github.com/zsyOAOA/DifFace/blob/65e8fef351b40177eaa6cb281aa997a644c0ed77/environment.yaml#L1